### PR TITLE
change imports from coreos to operator-framework in handler.go.tmpl

### DIFF
--- a/handler.go.tmpl
+++ b/handler.go.tmpl
@@ -6,10 +6,10 @@ import (
 
 	v1alpha1 "github.com/example-inc/memcached-operator/pkg/apis/cache/v1alpha1"
 
-	"github.com/coreos/operator-sdk/pkg/sdk/action"
-	"github.com/coreos/operator-sdk/pkg/sdk/handler"
-	"github.com/coreos/operator-sdk/pkg/sdk/query"
-	"github.com/coreos/operator-sdk/pkg/sdk/types"
+	"github.com/operator-framework/operator-sdk/pkg/sdk/action"
+	"github.com/operator-framework/operator-sdk/pkg/sdk/handler"
+	"github.com/operator-framework/operator-sdk/pkg/sdk/query"
+	"github.com/operator-framework/operator-sdk/pkg/sdk/types"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"


### PR DESCRIPTION
If you install the operator-sdk with instructions from https://github.com/operator-framework/operator-sdk/blob/master/README.md#L36 it tells you to install in `$GOPATH/src/github.com/operator-framework/operator-sdk` .  This just updates the imports to be consistent, as that broke when I tried following this guide. 