### PR TITLE
Update operator deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Deploy the Memcached Operator:
 
 ```sh
 $ kubectl create -f deploy/rbac.yaml
+$ kubectl create -f deploy/crd.yaml
 $ kubectl create -f deploy/operator.yaml
 ```
 


### PR DESCRIPTION
The latest version of code moved the crd in original operator.yaml in its own file crd.yaml. Just deploying operator.yaml causes crash due to missing CRD.