### PR TITLE
Corrected description of new call in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Use the CLI to create a new `memcached-operator` project:
 
 ```sh
 $ cd $GOPATH/src/github.com/example-inc/
-$ operator-sdk new memcached-operator --api-version=cache.example.com/v1alpha1 --kind=Memcached
+$ operator-sdk new memcached-operator 
 $ cd memcached-operator
+$ operator-sdk add api --api-version=cache.example.com/v1alpha1 --kind=Memcached
 ```
 
 This creates the `memcached-operator` project specifically for watching the `Memcached` resource with APIVersion `cache.example.com/v1apha1` and Kind `Memcached`.


### PR DESCRIPTION
Trying to run `new` with the `--api-version` cli flag resulted in the following error: 

```
operator-sdk new memcached-operator --api-version=cache.example.com/v1alpha1 -
2018/11/06 18:09:53 go type operator does not use --api-version or --kind. Please see "operator
```
Looking into https://github.com/operator-framework/operator-sdk#quick-start I adapted the this readme to use `new` and `add` commands separately.

Hope this change makes sense.