### PR TITLE
Fix indentation for OperatorGroup manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,9 +345,9 @@ kind: OperatorGroup
 metadata:
   name: memcached-operator-group
   namespace: default
-  spec:
-    targetNamespaces:
-    - default
+spec:
+  targetNamespaces:
+  - default
 ```
 
 Next create the CSV.


### PR DESCRIPTION
Fix for the https://github.com/operator-framework/getting-started/issues/40
