### PR TITLE
Replaces deprecated command options

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,12 +304,12 @@ This method is preferred during development cycle to deploy and test faster.
 Run the operator locally with the default kubernetes config file present at `$HOME/.kube/config`:
 
 ```sh
-$ operator-sdk run --local --watch-namespace=default
-INFO[0000] Running the operator locally in namespace default.
-{"level":"info","ts":1580761578.693055,"logger":"cmd","msg":"Operator Version: 0.0.1"}
-{"level":"info","ts":1580761578.6931021,"logger":"cmd","msg":"Go Version: go1.13.1"}
-{"level":"info","ts":1580761578.693109,"logger":"cmd","msg":"Go OS/Arch: darwin/amd64"}
-{"level":"info","ts":1580761578.693113,"logger":"cmd","msg":"Version of operator-sdk: v0.15.1"}
+$ operator-sdk run local
+INFO[0000] Running the operator locally; watching namespace "default"
+{"level":"info","ts":1593777657.892013,"logger":"cmd","msg":"Operator Version: 0.0.1"}
+{"level":"info","ts":1593777657.892079,"logger":"cmd","msg":"Go Version: go1.14.4"}
+{"level":"info","ts":1593777657.892084,"logger":"cmd","msg":"Go OS/Arch: darwin/amd64"}
+{"level":"info","ts":1593777657.892087,"logger":"cmd","msg":"Version of operator-sdk: v0.18.2"}
 ...
 ```
 


### PR DESCRIPTION
`operator-sdk run --local --watch-namespace=default` => `operator-sdk run local`